### PR TITLE
Fix dark mode titles

### DIFF
--- a/static/css/lanyon.css
+++ b/static/css/lanyon.css
@@ -561,5 +561,15 @@ a.pagination-item:hover {
 }
 
 img {
-	height: auto;
+  height: auto;
+}
+
+/* Tweak the default dark mode to ensure masthead and titles are legible. */
+@media (prefers-color-scheme: dark) {
+  .page-title, .post-title, .post-title a {
+    color: #E5E9EC;
+  }
+  .masthead-title a {
+    color: #B8C3CC;
+  }
 }


### PR DESCRIPTION
These changes make the site title and post titles accessible on dark mode. They also fix a mega-indent on the last-made change.

Before:

![Avi_Schwab_—_Private_Browsing](https://github.com/microdotblog/theme-lanyon/assets/238201/f5175ace-1535-479d-997f-79b836d6c719)

After:

![Avi_Schwab_—_Private_Browsing](https://github.com/microdotblog/theme-lanyon/assets/238201/2c5c442b-39e3-4e5c-ad45-c9cb3509bd20)
